### PR TITLE
Enhanced chart features, fixed competitor analysis, and UX updates #IEEESOC

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -102,12 +102,12 @@ def fetch_wikipedia_summary(company_name):
         return None, f"Error fetching Wikipedia summary: {str(e)}" 
     return None, "No Wikipedia page found for the given company." 
  
-def fetch_stock_price(ticker): 
+def fetch_stock_price(ticker, time_range="3mo"): 
     try: 
         # Set a timeout for the request
         stock = yf.Ticker(ticker)
-        # Use a longer period (3mo instead of 1mo) for more detailed response
-        history = stock.history(period="3mo")
+        # Use the provided time range
+        history = stock.history(period=time_range)
         
         if history.empty:
             print(f"No stock price data found for {ticker}")
@@ -115,9 +115,17 @@ def fetch_stock_price(ticker):
             import datetime
             import random
             today = datetime.datetime.now()
-            time_labels = [(today - datetime.timedelta(days=i)).strftime('%Y-%m-%d') for i in range(90, 0, -1)]
+            
+            # Adjust the number of days based on time range
+            days = {
+                "1wk": 7,
+                "1mo": 30,
+                "3mo": 90
+            }.get(time_range, 90)
+            
+            time_labels = [(today - datetime.timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days, 0, -1)]
             base_price = 100.0
-            stock_prices = [round(base_price + random.uniform(-10, 10), 2) for _ in range(90)]
+            stock_prices = [round(base_price + random.uniform(-10, 10), 2) for _ in range(days)]
             return stock_prices, time_labels
             
         time_labels = history.index.strftime('%Y-%m-%d').tolist() 
@@ -129,9 +137,17 @@ def fetch_stock_price(ticker):
         import datetime
         import random
         today = datetime.datetime.now()
-        time_labels = [(today - datetime.timedelta(days=i)).strftime('%Y-%m-%d') for i in range(90, 0, -1)]
+        
+        # Adjust the number of days based on time range
+        days = {
+            "1wk": 7,
+            "1mo": 30,
+            "3mo": 90
+        }.get(time_range, 90)
+        
+        time_labels = [(today - datetime.timedelta(days=i)).strftime('%Y-%m-%d') for i in range(days, 0, -1)]
         base_price = 100.0
-        stock_prices = [round(base_price + random.uniform(-10, 10), 2) for _ in range(90)]
+        stock_prices = [round(base_price + random.uniform(-10, 10), 2) for _ in range(days)]
         return stock_prices, time_labels
 
 def get_ticker_from_alpha_vantage(company_name): 
@@ -267,7 +283,7 @@ def get_top_competitors(competitors):
     top_competitors = sorted(competitor_data, key=lambda x: x["market_cap"], reverse=True)[:3] 
     return top_competitors 
  
-def query_gemini_llm(description): 
+def query_gemini_llm(company_name): 
     try: 
         # Check if client is defined (it might not be if API key is invalid)
         if 'client' not in globals():
@@ -285,15 +301,16 @@ def query_gemini_llm(description):
             ]
             
         prompt = f""" 
-        Provide a structured list of sectors and their competitors for the following company description: 
-        {description[:500]} 
+        Based on the company name "{company_name}", provide a structured list of sectors and their main competitors.
+        Focus on direct competitors in the same industry and market.
         Format: 
         Sector Name : 
             Competitor 1 
             Competitor 2 
             Competitor 3 
  
-        Leave a line after each sector. Do not use bullet points. 
+        Leave a line after each sector. Do not use bullet points.
+        Only include major, publicly traded companies that are direct competitors.
         """ 
         
         try:
@@ -342,6 +359,8 @@ def query_gemini_llm(description):
 @login_required
 def analyze_company():
     company_name = request.args.get("company_name")
+    time_range = request.args.get("time_range", "3mo")  # Default to 3 months if not specified
+    
     if not company_name:
         return jsonify(success=False, error="No company name provided.")
 
@@ -353,16 +372,22 @@ def analyze_company():
     if not ticker:  
         return jsonify(success=False, error="Could not find ticker symbol.")
 
-    stock_prices, time_labels = fetch_stock_price(ticker)
+    stock_prices, time_labels = fetch_stock_price(ticker, time_range)
     if not stock_prices or not time_labels:
         return jsonify(success=False, error="Could not fetch stock prices.")
 
-    competitors = query_gemini_llm(summary)
-    if not competitors:
-        competitors = [{"name": "No Sectors", "competitors": ["No competitors found."]}]
+    # Only fetch competitors if this is the initial request (not a time range update)
+    if time_range == "3mo":
+        competitors = query_gemini_llm(company_name)  # Changed to pass company_name instead of summary
+        if not competitors:
+            competitors = [{"name": "No Sectors", "competitors": ["No competitors found."]}]
 
-    all_competitors = [comp for sector in competitors for comp in sector["competitors"]]
-    top_competitors = get_top_competitors(all_competitors)
+        all_competitors = [comp for sector in competitors for comp in sector["competitors"]]
+        top_competitors = get_top_competitors(all_competitors)
+    else:
+        # For time range updates, we don't need to fetch competitors again
+        competitors = []
+        top_competitors = []
 
     return jsonify(
         success=True,

--- a/templates/FRONT.html
+++ b/templates/FRONT.html
@@ -90,6 +90,11 @@
 
         <div id="graphSection" class="result-card chart-card" style="display: none;">
           <h3><i class="fas fa-chart-line"></i> Stock Price History</h3>
+          <div class="time-range-selector">
+            <button class="time-range-btn active" data-range="3mo">3 Months</button>
+            <button class="time-range-btn" data-range="1mo">1 Month</button>
+            <button class="time-range-btn" data-range="1wk">1 Week</button>
+          </div>
           <canvas id="stockGraph"></canvas>
         </div>
 
@@ -137,6 +142,7 @@
 
     let stockChartInstance = null;
     let topCompetitorsChartInstance = null;
+    let currentTicker = null;
 
     // Function to animate section reveal
     function revealSection(sectionElement) {
@@ -147,6 +153,26 @@
         }, 50); // A small delay
     }
 
+    // Add this function to handle time range changes
+    function updateTimeRange(range) {
+      if (!currentTicker) return;
+      
+      loadingText.style.display = 'block';
+      fetch(`/service/analyze_company?company_name=${currentTicker}&time_range=${range}`)
+        .then(response => response.json())
+        .then(data => {
+          if (data.success) {
+            renderGraph(data.stock_prices, data.time_labels);
+          }
+        })
+        .catch(error => {
+          console.error('Error:', error);
+          alert('Error updating time range. Please try again.');
+        })
+        .finally(() => {
+          loadingText.style.display = 'none';
+        });
+    }
 
     companyForm.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -157,11 +183,12 @@
         return;
       }
 
+      currentTicker = companyName;
+
       loadingText.style.display = 'flex'; // Changed to flex for spinner alignment
       resultsSection.style.display = 'none'; // Hide previous results
       // Remove 'visible' class from all result cards for re-animation
       document.querySelectorAll('.result-card, .results-section').forEach(el => el.classList.remove('visible'));
-
 
       try {
         const apiUrl = window.location.origin;
@@ -198,7 +225,6 @@
             competitorsSection.style.display = 'none';
           }
 
-
           if (data.top_competitors && data.top_competitors.length > 0) {
             const topCompetitorsListEl = document.getElementById('topCompetitorsList');
             topCompetitorsListEl.innerHTML = ''; // Clear previous
@@ -214,11 +240,9 @@
             });
             renderTopCompetitorsGraph(data.top_competitors);
             revealSection(topCompetitorsSection);
-
           } else {
             topCompetitorsSection.style.display = 'none';
           }
-
         } else {
           // Implement a more user-friendly error display
           alert(data.error || 'Error fetching data. Please try again.');
@@ -248,13 +272,40 @@
                 }
             },
             tooltip: {
-                backgroundColor: 'rgba(0,0,0,0.7)',
-                titleFont: { family: "'Poppins', sans-serif", size: 14 },
-                bodyFont: { family: "'Poppins', sans-serif", size: 12 },
-                padding: 10,
-                cornerRadius: 4,
-                displayColors: true
+                backgroundColor: 'rgba(0,0,0,0.8)',
+                titleFont: { family: "'Poppins', sans-serif", size: 14, weight: 'bold' },
+                bodyFont: { family: "'Poppins', sans-serif", size: 13 },
+                padding: 12,
+                cornerRadius: 6,
+                displayColors: true,
+                callbacks: {
+                    label: function(context) {
+                        let label = context.dataset.label || '';
+                        if (label) {
+                            label += ': ';
+                        }
+                        if (context.parsed.y !== null) {
+                            label += new Intl.NumberFormat('en-US', { 
+                                style: 'currency', 
+                                currency: 'USD',
+                                minimumFractionDigits: 2,
+                                maximumFractionDigits: 2
+                            }).format(context.parsed.y);
+                        }
+                        return label;
+                    },
+                    title: function(context) {
+                        return context[0].label;
+                    }
+                },
+                intersect: false,
+                mode: 'index'
             }
+        },
+        interaction: {
+            mode: 'nearest',
+            axis: 'x',
+            intersect: false
         },
         scales: {
             x: {
@@ -297,7 +348,9 @@
             pointBackgroundColor: '#007bff',
             pointBorderColor: '#ffffff',
             pointHoverBackgroundColor: '#ffffff',
-            pointHoverBorderColor: '#0056b3'
+            pointHoverBorderColor: '#0056b3',
+            pointRadius: 4,  // Increased from default
+            pointHoverRadius: 6  // Increased from default
           }],
         },
         options: chartDefaultOptions
@@ -329,7 +382,7 @@
 
         return {
           label: comp.name,
-          data: comp.stock_prices, // Assuming each competitor has its own stock_prices array
+          data: comp.stock_prices,
           borderColor: baseColor,
           backgroundColor: gradient,
           fill: true,
@@ -337,7 +390,9 @@
           pointBackgroundColor: baseColor,
           pointBorderColor: '#ffffff',
           pointHoverBackgroundColor: '#ffffff',
-          pointHoverBorderColor: hexToRgba(baseColor, 0.8)
+          pointHoverBorderColor: hexToRgba(baseColor, 0.8),
+          pointRadius: 4,  // Increased from default
+          pointHoverRadius: 6  // Increased from default
         };
       });
       
@@ -351,6 +406,54 @@
         options: chartDefaultOptions
       });
     }
+
+    // Add event listeners for time range buttons
+    document.querySelectorAll('.time-range-btn').forEach(button => {
+      button.addEventListener('click', (e) => {
+        // Remove active class from all buttons
+        document.querySelectorAll('.time-range-btn').forEach(btn => {
+          btn.classList.remove('active');
+        });
+        // Add active class to clicked button
+        e.target.classList.add('active');
+        // Update the graph with new time range
+        updateTimeRange(e.target.dataset.range);
+      });
+    });
   </script>
+
+  <style>
+    .time-range-selector {
+      display: flex;
+      gap: 15px;  /* Increased gap between buttons */
+      margin-bottom: 20px;  /* Increased bottom margin */
+      justify-content: center;
+    }
+
+    .time-range-btn {
+      padding: 12px 24px;  /* Increased padding */
+      border: 1px solid var(--border-color);
+      background-color: var(--surface-color);
+      color: var(--text-primary-color);
+      border-radius: var(--border-radius-sm);
+      cursor: pointer;
+      transition: all 0.3s ease;
+      font-size: 1.1rem;  /* Increased font size */
+      font-weight: 500;  /* Added medium font weight */
+      min-width: 120px;  /* Added minimum width */
+    }
+
+    .time-range-btn:hover {
+      background-color: var(--surface-highlight);
+      transform: translateY(-2px);  /* Added slight lift effect on hover */
+    }
+
+    .time-range-btn.active {
+      background-color: var(--primary-color);
+      color: white;
+      border-color: var(--primary-color);
+      font-weight: 600;  /* Made active button text bolder */
+    }
+  </style>
 </body>
 </html>


### PR DESCRIPTION
This PR introduces a set of major improvements and feature additions to the StockMind project for a significantly better user experience, improved accuracy in competitor analysis, and more powerful stock visualizations.

## 1.  Time Range Selection for Stock Charts
- Added time range selector buttons (`1 Week`, `1 Month`, `3 Months`) to the stock graph UI.
- Dynamically updates the stock chart based on the selected time frame.
- Modified backend logic to support historical data fetching across these ranges.
- Enhanced responsiveness and button styling for better UX.

## 2.  Enhanced Chart Visualization
- Increased marker size and hover radius for improved chart readability.
- Customized tooltips to show:
  - **Nearest point detection to the cursor to display the tooltip**
  - Proper currency formatting
  - Clean and readable layout

## 3.  Improved Competitor Analysis
- Replaced Wikipedia description scraping with direct use of company name.
- Refined Gemini LLM prompt to:
  - Focus only on **publicly traded**, **direct competitors** in the **same industry**
  - Avoid non-sector-specific or private companies
- Significantly improved the accuracy of peer competitor suggestions.

## 4.  UI/UX Improvements
- Added loading indicators while fetching data from APIs.
- Smooth animation for graph and section reveals.
- Responsive layout for mobile and tablets.
- Improved error handling and clear user feedback messages.

---

### 🧪 Testing
Tested across:
- Multiple companies (e.g., Apple, Tesla, Google)
- Various time ranges
- Desktop and mobile views

Time Range Selection for Stock Charts:
![image](https://github.com/user-attachments/assets/745c1a47-30bb-44ef-9af9-3858ff393fcd)

Nearest point detection to the cursor to display the tooltip:
![image](https://github.com/user-attachments/assets/1f15c470-e1d9-4436-a702-b50cadfab6f9)

Improved Competitor Analysis
For example if pepsi was the company to be analysed, this is how the peer competitors should display:
![image](https://github.com/user-attachments/assets/52c62709-7209-4134-a581-b0530b52ee11)

